### PR TITLE
CL-3378 add unique ids for pjmedia_aud_dev_info

### DIFF
--- a/pjmedia/include/pjmedia/audiodev.h
+++ b/pjmedia/include/pjmedia/audiodev.h
@@ -300,7 +300,7 @@ typedef struct pjmedia_aud_dev_info
     /*
      * The device id
      */
-    char id[384];
+    char id[192];
 
     /** 
      * Maximum number of input channels supported by this device. If the

--- a/pjmedia/include/pjmedia/audiodev.h
+++ b/pjmedia/include/pjmedia/audiodev.h
@@ -297,6 +297,11 @@ typedef struct pjmedia_aud_dev_info
      */
     char name[PJMEDIA_AUD_DEV_INFO_NAME_LEN];
 
+    /*
+     * The device id
+     */
+    char id[384];
+
     /** 
      * Maximum number of input channels supported by this device. If the
      * value is zero, the device does not support input operation (i.e.

--- a/pjmedia/src/pjmedia-audiodev/coreaudio_dev.m
+++ b/pjmedia/src/pjmedia-audiodev/coreaudio_dev.m
@@ -537,15 +537,35 @@ static pj_status_t ca_factory_refresh(pjmedia_aud_dev_factory *f)
 	struct coreaudio_dev_info *cdi;
 	Float64 sampleRate;
 
-	cdi = &cf->dev_info[i];
-	pj_bzero(cdi, sizeof(*cdi));
-	cdi->dev_id = dev_ids[i];
+    cdi = &cf->dev_info[i];
+    pj_bzero(cdi, sizeof(*cdi));
+    cdi->dev_id = dev_ids[i];
+    
+    /* Get device unique id */
+    addr.mSelector = kAudioDevicePropertyDeviceUID;
+    addr.mScope = kAudioObjectPropertyScopeGlobal;
+    addr.mElement = kAudioObjectPropertyElementMaster;
 
-	/* Get device name */
-	addr.mSelector = kAudioDevicePropertyDeviceName;
-	addr.mScope = kAudioObjectPropertyScopeGlobal;
-	addr.mElement = kAudioObjectPropertyElementMaster;
-	size = sizeof(cdi->info.name);
+    CFStringRef uid;
+    size = sizeof(CFStringRef);
+
+    ostatus = AudioObjectGetPropertyData(cdi->dev_id, &addr, 0, NULL, &size, &uid);
+
+    if (ostatus == noErr) {
+        Boolean success = CFStringGetCString(uid, cdi->info.id, sizeof(cdi->info.id), kCFStringEncodingUTF8);
+        if(!success) {
+                PJ_LOG(1, (THIS_FILE, "failed to copy id to buffer"));
+        }
+    } else {
+        PJ_LOG(1, (THIS_FILE, " failed to copy id to buffer"));
+    }
+    CFRelease(uid);
+    
+    /* Get device name */
+    addr.mSelector = kAudioDevicePropertyDeviceName;
+    addr.mScope = kAudioObjectPropertyScopeGlobal;
+    addr.mElement = kAudioObjectPropertyElementMaster;
+    size = sizeof(cdi->info.name);
 	AudioObjectGetPropertyData(cdi->dev_id, &addr,
 				   0, NULL,
 			           &size, (void *)cdi->info.name);

--- a/pjmedia/src/pjmedia-audiodev/wmme_dev.c
+++ b/pjmedia/src/pjmedia-audiodev/wmme_dev.c
@@ -285,6 +285,11 @@ static void get_dev_names(pjmedia_aud_dev_factory *f)
 				   wf->dev_info[i].info.name, 
 				   sizeof(wf->dev_info[i].info.name));
 
+		pj_unicode_to_ansi(wf->dev_info[i].endpointId, 
+				   wcslen(wf->dev_info[i].endpointId), 
+				   wf->dev_info[i].info.id, 
+				   sizeof(wf->dev_info[i].info.id));
+
 		break;
 	    }
 	}


### PR DESCRIPTION
Add a new unique id property for audio devices, and use it from coreaudio.